### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- configure Dependabot to monitor npm packages and GitHub Actions weekly

## Testing
- `npx @biomejs/biome check` *(fails: formatting issues in existing files)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6899952bb3c4833195ac9c34b044a941