### PR TITLE
Add mock Discord webhook unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev --test-scheduled",
     "start": "wrangler dev --test-scheduled",
-    "cf-typegen": "wrangler types"
+    "cf-typegen": "wrangler types",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/src/mock.test.ts
+++ b/src/mock.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { mockRequestDiscordWebhook } from "./mock";
+
+// Unit test for mockRequestDiscordWebhook
+
+describe("mockRequestDiscordWebhook", () => {
+  it("returns a function that posts to Discord", async () => {
+    const item = { title: "Example", linkHash: "abc123" };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const send = await mockRequestDiscordWebhook(item);
+    const response = send();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      `Sending message to Discord: ${item.title} - ${item.linkHash}`,
+    );
+    expect(response instanceof Response).toBe(true);
+    await expect(response.json()).resolves.toEqual({ test: true });
+
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add npm script to run vitest
- test mockRequestDiscordWebhook returns expected response and logs

## Testing
- `npx biome check package.json src/mock.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68999ac4209c83318aeb6a3c988b82fd