### PR TITLE
chore: update Biome config for v2

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,20 +1,24 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["worker-configuration.d.ts", ".wrangler"]
+    "ignoreUnknown": false
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space"
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   },
   "linter": {
     "enabled": true,
@@ -22,6 +26,17 @@
       "recommended": true
     }
   },
+  "overrides": [
+    {
+      "includes": ["worker-configuration.d.ts"],
+      "linter": {
+        "enabled": false
+      },
+      "formatter": {
+        "enabled": false
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "double"

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ const processFeed = async (target: TargetOption, env: Env): Promise<void> => {
 const handleScheduled = async (
   event: ScheduledController,
   env: Env,
-  ctx: ExecutionContext,
+  _ctx: ExecutionContext,
 ): Promise<void> => {
   try {
     await Promise.all(
@@ -148,7 +148,7 @@ const exportable: ExportedHandler<Env> =
       }
     : {
         fetch: async (
-          req: Request<unknown, IncomingRequestCfProperties<unknown>>,
+          _req: Request<unknown, IncomingRequestCfProperties<unknown>>,
         ) => {
           return new Response("", { status: 200, statusText: "OK" });
         },


### PR DESCRIPTION
## Summary
- update Biome configuration to new v2 schema and organizeImports assist
- disable lint/format for generated worker-configuration types
- prefix unused handler params with underscores

## Testing
- `npx biome check .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b337828c48331861acd09c61c4c1c