### PR TITLE
Add Nix flake for dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ npm install
 npm run dev
 ```
 
+### Nix を使ったセットアップ
+Nix を使う場合は flake を利用した開発シェルを用意しています。
+
+```bash
+nix develop
+```
+
+`node_modules` は `npmlock2nix` を通じてロックファイルから復元されるため、追加の `npm install` は不要です。`node_modules/.bin` が PATH に追加されるので、`npm run dev` や `npm test` など既存の npm スクリプトをそのまま実行できます。
+
+依存モジュールだけを取得したい場合は次のコマンドで `node_modules` をビルドできます。
+
+```bash
+nix build .#nodeModules
+```
+
 ## 今後学ぶと良いこと
 1. Cloudflare Workers の基礎（Cron、KV、環境変数）
 2. `htmlparser2` による RSS/HTML パーシングと `p-retry` のリトライ戦略

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "RSS Feed Worker with Nix-managed dependencies";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    npmlock2nix = {
+      url = "github:nix-community/npmlock2nix";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, npmlock2nix }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ] (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        n2n = import npmlock2nix { inherit pkgs; };
+        nodeModules = n2n.v2.node_modules {
+          src = ./.;
+          nodejs = pkgs.nodejs_20;
+        };
+      in {
+        packages = {
+          default = nodeModules;
+          nodeModules = nodeModules;
+        };
+
+        devShells.default =
+          n2n.v2.shell {
+            src = ./.;
+            nodejs = pkgs.nodejs_20;
+            node_modules_attrs = {
+              nodejs = pkgs.nodejs_20;
+            };
+            buildInputs = with pkgs; [
+              nodejs_20
+              git
+            ];
+            shellHook = ''
+              export PATH="$PWD/node_modules/.bin:$PATH"
+            '';
+          };
+      });
+}


### PR DESCRIPTION
## Summary
- add a Nix flake that uses npmlock2nix to provide reproducible node_modules and a dev shell
- document how to use the flake for development and building dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf7dc09d988331a9ff66427747794c